### PR TITLE
Fix the google-analytics ID tag

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,3 +1,3 @@
 [output.html]
 no-section-label = true
-google_analytics_id = "UA-144588868-3"
+google-analytics = "UA-144588868-3"


### PR DESCRIPTION
Noticed that #8 used the initial version. After that got merged,
checked the site, and GA was not present. When searched the
documentation found option as 'google-analytics'.

Ref: https://rust-lang.github.io/mdBook/format/config.html#html-renderer-options

Fixes: #7